### PR TITLE
Add programs to data returned by course round list API-endpoint

### DIFF
--- a/__tests__/API/__snapshots__/listCourseRounds.spec.ts.snap
+++ b/__tests__/API/__snapshots__/listCourseRounds.spec.ts.snap
@@ -67,6 +67,15 @@ exports[`/api/course-rounds can be executed 1`] = `
           "period": "P1",
         },
       ],
+      "programs": [
+        {
+          "code": "ARKIT",
+          "name": "Arkitektur",
+          "required": "obligatorisk",
+          "startTerm": "20221",
+          "studyYear": 4,
+        },
+      ],
     },
     {
       "canceled": false,
@@ -125,6 +134,19 @@ exports[`/api/course-rounds can be executed 1`] = `
         {
           "credits": "6 hp",
           "period": "P3",
+        },
+      ],
+      "programs": [
+        {
+          "code": "BIO",
+          "name": "Biologi och bioteknik",
+          "required": "obligatorisk",
+          "specialization": {
+            "code": "BMRU",
+            "name": "Biokemi och molekylärbiologianalys med Rust",
+          },
+          "startTerm": "20231",
+          "studyYear": 1,
         },
       ],
     },

--- a/openapi/course-survey-integration-api.spec.yml
+++ b/openapi/course-survey-integration-api.spec.yml
@@ -218,6 +218,7 @@ components:
         - institution
         - courseGoal
         - periods
+        - programs
         - credits
         - courseExaminers
         - courseResponsible
@@ -287,6 +288,11 @@ components:
               credits:
                 type: string
                 description: "Credits awarded for this period."
+        programs:
+          type: array
+          description: "List of programs this course round is part of according to registered students."
+          items:
+            $ref: "#/components/schemas/ProgramRound"
         credits:
           type: string
           description: "Total credits awarded for this course."
@@ -313,7 +319,6 @@ components:
             - totalRegisteredStudents
             - totalReportedResults
             - gradingDistribution
-            - programs
             - modules
           properties:
             totalRegisteredStudents:
@@ -328,11 +333,6 @@ components:
               example: '{ "A": 3, "B": 25, "C": 15, "D": 3, "E": 0, "F": 2 }'
               additionalProperties:
                 type: number
-            programs:
-              type: array
-              description: "List of programs this course round is part of according to registered students."
-              items:
-                $ref: "#/components/schemas/ProgramRound"
             modules:
               type: array
               description: "List of modules that are part of this course round, including grading distribution etc."

--- a/src/__generated__/_interface.ts
+++ b/src/__generated__/_interface.ts
@@ -164,6 +164,8 @@ export interface components {
           /** @description Credits awarded for this period. */
           credits: string;
         })[];
+      /** @description List of programs this course round is part of according to registered students. */
+      programs: components["schemas"]["ProgramRound"][];
       /** @description Total credits awarded for this course. */
       credits: string;
       /** @description List of examiners for this _course_. */
@@ -185,8 +187,6 @@ export interface components {
       gradingDistribution: {
         [key: string]: number;
       };
-      /** @description List of programs this course round is part of according to registered students. */
-      programs: components["schemas"]["ProgramRound"][];
       /** @description List of modules that are part of this course round, including grading distribution etc. */
       modules: components["schemas"]["CourseModule"][];
     };

--- a/src/functions/api/getCourseRound.ts
+++ b/src/functions/api/getCourseRound.ts
@@ -3,7 +3,7 @@ import {
   HttpResponseInit,
   InvocationContext,
 } from "@azure/functions";
-import { APICourseRound, APICourseRoundParams, TCourseModule, TCourseRoundModuleEntity, TReportedResultEntity } from "../interface";
+import { APICourseRound, APICourseRoundParams, TCourseModule, TCourseRoundModuleEntity, TProgramRound, TReportedResultEntity } from "../interface";
 import { Database } from "../utils";
 
 export default async function handler<T extends APICourseRound>(
@@ -57,7 +57,7 @@ export default async function handler<T extends APICourseRound>(
     );
 
     const programs = studentParticipations.reduce(
-      (acc: Record<string, number>, res: any) => {
+      (acc: Record<string, TProgramRound>, res: any) => {
         acc[res.program.code] ??= res.program;
         return acc;
       },


### PR DESCRIPTION
Artisan has requested that we expose program relations already in the list of courses. They have technical limitations that can cause leaking ports and want to minimise number of outgoing requests from their server.