### PR TITLE
Stable sorting for paging

### DIFF
--- a/__tests__/API/__snapshots__/getCourseRoundStudents.spec.ts.snap
+++ b/__tests__/API/__snapshots__/getCourseRoundStudents.spec.ts.snap
@@ -46,3 +46,15 @@ exports[`/api/course-rounds/{id}/students can be executed 1`] = `
   "status": 200,
 }
 `;
+
+exports[`/api/course-rounds/{id}/students sorts results for stable pagination results 1`] = `
+[
+  undefined,
+  {
+    "limit": 30,
+    "offset": 0,
+    "sortBy": "_id",
+    "sortOrder": "asc",
+  },
+]
+`;

--- a/__tests__/API/__snapshots__/listCourseRounds.spec.ts.snap
+++ b/__tests__/API/__snapshots__/listCourseRounds.spec.ts.snap
@@ -160,3 +160,17 @@ exports[`/api/course-rounds can be executed 1`] = `
   "status": 200,
 }
 `;
+
+exports[`/api/course-rounds sorts results for stable pagination results 1`] = `
+[
+  undefined,
+  {
+    "limit": 30,
+    "offset": 0,
+    "sortBy": "_id",
+    "sortOrder": "asc",
+  },
+  undefined,
+  undefined,
+]
+`;

--- a/__tests__/API/getCourseRoundStudents.spec.ts
+++ b/__tests__/API/getCourseRoundStudents.spec.ts
@@ -35,4 +35,11 @@ describe("/api/course-rounds/{id}/students", () => {
     const outp = await handler(mockRequest, mockContext, mockDb);
     expect(outp).toMatchSnapshot();
   });
+  test("sorts results for stable pagination results", async () => {
+    const mockDb = new MockDatabase(mockDbData);
+    const mockContext = new MockContext();
+    const mockRequest = new MockRequest({ params: { id: "01-1" } });
+    const outp = await handler(mockRequest, mockContext, mockDb);
+    expect(mockDb._queryOptions).toMatchSnapshot();
+  });
 });

--- a/__tests__/API/listCourseRounds.spec.ts
+++ b/__tests__/API/listCourseRounds.spec.ts
@@ -35,4 +35,11 @@ describe("/api/course-rounds", () => {
     const outp = await handler(mockRequest, mockContext, mockDb);
     expect(outp).toMatchSnapshot();
   });
+  test("sorts results for stable pagination results", async () => {
+    const mockDb = new MockDatabase(mockDbData);
+    const mockContext = new MockContext();
+    const mockRequest = new MockRequest();
+    const outp = await handler(mockRequest, mockContext, mockDb);
+    expect(mockDb._queryOptions).toMatchSnapshot();
+  });
 });

--- a/__tests__/utils/mockDatabase.ts
+++ b/__tests__/utils/mockDatabase.ts
@@ -1,4 +1,4 @@
-import { Database, DbCollectionName } from "../../src/functions/db";
+import { Database, DbCollectionName, TQueryOptions } from "../../src/functions/db";
 
 type TQuery = {
   query: string;
@@ -9,6 +9,7 @@ export class MockDatabase implements Database {
   _result: Record<DbCollectionName, any>;
   _mockData: Record<DbCollectionName, any>;
   _client: any;
+  _queryOptions: (TQueryOptions | undefined)[];
 
   // I would have prefered narrowing keys to DbCollectionName but
   // the syntax Record<DbCollectionName, any> requires all keys
@@ -19,6 +20,7 @@ export class MockDatabase implements Database {
   constructor(mockData: Record<string, any> | undefined = undefined) {
     this._mockData = mockData ?? ({} as Record<DbCollectionName, TQuery | any>);
     this._result = {} as Record<DbCollectionName, any>;
+    this._queryOptions = [ ]
   }
 
   async connect(): Promise<void> {
@@ -39,7 +41,9 @@ export class MockDatabase implements Database {
     propName: string,
     value: string,
     collectionName: DbCollectionName,
+    options?: TQueryOptions
   ): Promise<any[]> {
+    this._queryOptions.push(options);
     const data = this._mockData[collectionName];
     const outp = Array.isArray(data) ? data : [data];
     
@@ -57,7 +61,12 @@ export class MockDatabase implements Database {
    * @param collectionName
    * @returns
    */
-  async query(query: any, collectionName: DbCollectionName): Promise<any[]> {
+  async query(
+    query: any,
+    collectionName: DbCollectionName,
+    options?: TQueryOptions,
+  ): Promise<any[]> {
+    this._queryOptions.push(options);
     const data = this._mockData[collectionName];
     const outp = Array.isArray(data) ? data : [data];
     return outp

--- a/openapi/course-survey-integration-api.spec.yml
+++ b/openapi/course-survey-integration-api.spec.yml
@@ -193,7 +193,7 @@ components:
         type: integer
         description: The limit of course rounds per page.
         minimum: 1
-        maximum: 30
+        maximum: 100
         default: 30
   parameters:
     PageLimit:
@@ -203,7 +203,7 @@ components:
       schema:
         type: integer
         minimum: 1
-        maximum: 30
+        maximum: 100
         default: 30
       required: false
     PageOffset:

--- a/src/functions/api/getCourseRoundStudents.ts
+++ b/src/functions/api/getCourseRoundStudents.ts
@@ -45,7 +45,9 @@ export default async function handler<T extends APICourseRoundStudentList>(
       "ladokCourseRoundId",
       ladokCourseRoundId,
       "StudentParticipation",
-      { offset, limit },
+      // Paging requires stable sort order, otherwise we may
+      // skip or duplicate items
+      { offset, limit, sortBy: "_id", sortOrder: "asc"},
     );
 
     outp = students.map(({

--- a/src/functions/api/getCourseRoundStudents.ts
+++ b/src/functions/api/getCourseRoundStudents.ts
@@ -14,7 +14,7 @@ export default async function handler<T extends APICourseRoundStudentList>(
   let offset = parseInt(request.query.get("offset") ?? "0");
   if (offset < 0) offset = 0;
   let limit = parseInt(request.query.get("limit") ?? "30");
-  if (limit > 30) limit = 30;
+  if (limit > 100) limit = 100;
 
   const { id } = request.params as APICourseRoundStudentListParams["path"];
 

--- a/src/functions/api/listCourseRounds.ts
+++ b/src/functions/api/listCourseRounds.ts
@@ -29,7 +29,7 @@ export default async function handler<T extends APICourseRoundList>(
   if (offset < 0) offset = 0;
   let limit = parseInt(request.query.get("limit") ?? "30");
   if (limit < 1) limit = 1;
-  if (limit > 30) limit = 30;
+  if (limit > 100) limit = 100;
 
   let outp: APICourseRoundList = [];
   let total;

--- a/src/functions/api/listCourseRounds.ts
+++ b/src/functions/api/listCourseRounds.ts
@@ -46,7 +46,9 @@ export default async function handler<T extends APICourseRoundList>(
       "endDate",
       { $lt: selectionEndDate, $gt: selectionStartDate },
       "CourseRound",
-      { offset, limit },
+      // Paging requires stable sort order, otherwise we may
+      // skip or duplicate items
+      { offset, limit, sortBy: "_id", sortOrder: "asc"},
     );
 
     // Add programmes to list of course rounds

--- a/src/functions/db.ts
+++ b/src/functions/db.ts
@@ -1,4 +1,4 @@
-import { MongoClient } from "mongodb";
+import { FindOptions, MongoClient } from "mongodb";
 
 const IS_PROD = process.env.NODE_ENV === "production";
 const {
@@ -58,6 +58,8 @@ export type DbCollectionName = "StudentParticipation" |
 export type TQueryOptions = {
   offset?: number;
   limit?: number;
+  sortBy?: "_id";
+  sortOrder?: "asc" | "desc";
 };
 
 export class Database {
@@ -90,9 +92,15 @@ export class Database {
     options?: TQueryOptions
   ): Promise<T[]> {
     await this.connect();
-    const opts = options !== undefined
+
+    // Query options and sorting
+    const opts: FindOptions<Document> | undefined = options !== undefined
       ? { skip: options.offset, limit: options.limit }
-      : undefined;
+      : {};
+    if (options?.sortBy) {
+      opts["sort"] = { [options.sortBy]: options.sortOrder === "asc" ? 1 : -1 };
+    }
+
     const collection = this._client!.db().collection(collectionName);
     const docs = await collection
       .find({ [propName]: value }, opts)
@@ -106,9 +114,15 @@ export class Database {
     options?: TQueryOptions
   ): Promise<T[]> {
     await this.connect();
-    const opts = options !== undefined
+
+    // Query options and sorting
+    const opts: FindOptions<Document> | undefined = options !== undefined
       ? { skip: options.offset, limit: options.limit }
-      : undefined;
+      : {};
+    if (options?.sortBy) {
+      opts["sort"] = { [options.sortBy]: options.sortOrder === "asc" ? 1 : -1 };
+    }
+
     const collection = this._client!.db().collection(collectionName);
     const docs = await collection.find(query, opts).toArray();
     return docs as T[];


### PR DESCRIPTION
Pagination requires stable sorting, otherwise we may miss entries or get duplicates as we fetch each page.

We are currently sorting ascending on _id which should be time sortable according to the format https://www.mongodb.com/docs/manual/reference/method/ObjectId/