### PR TITLE
Handle missing electiveCondition

### DIFF
--- a/src/functions/api/getCourseRound.ts
+++ b/src/functions/api/getCourseRound.ts
@@ -152,7 +152,7 @@ export function transformProgramRoundForApi(prog: TProgramRoundEntity, courseRou
     specialization,
   } = prog;
 
-  const koppsElectiveCondition = courseRound.electiveConditionsForPrograms.find(
+  const koppsElectiveCondition = courseRound.electiveConditionsForPrograms?.find(
     c => c.programmeCode === code && c.progAdmissionTerm?.term?.toString() === startTerm
   );
   const electiveConditionCode = koppsElectiveCondition?.electiveCondition.name;


### PR DESCRIPTION
If a course is missing elective condition, we should still be able to pass the data to the API